### PR TITLE
Assign multiple groups to undercloud during inventory creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,7 @@ overcloud_user: heat-admin
 
 # Virtual environment path
 venv_path: "/tmp/ansible_venv"
+
+# Define the groups, Undercloud host should be added to.
+# multiple groups should be separated by the comma.
+undercloud_groups: undercloud,tester

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: Add baremetal Undercloud to host list
   add_host:
     name: "undercloud-0"
-    groups: "undercloud,tester"
+    groups: "{{ undercloud_groups }}"
     ansible_ssh_host: "{{ host }}"
     ansible_ssh_user: "{{ user | default('stack') }}"
     ansible_ssh_private_key_file: "{{ ssh_key | default(omit) }}"
@@ -39,7 +39,7 @@
   when: setup_type == 'baremetal'
 
 - name: Locate virt Undercloud and add to host list
-  include: hypervisor.yml
+  include_tasks: hypervisor.yml
   when: setup_type == 'virt'
 
 - name: Generate Inventory file
@@ -50,23 +50,23 @@
     dest: "{{ environment_dir }}/inventory_{{ host }}"
 
 - name: Generate and set an SSH key if password is used
-  include: undercloud_pass.yml
+  include_tasks: undercloud_pass.yml
   when: ssh_pass is defined
 
 - name: Create TripleO inventory
-  include: overcloud_nodes.yml
+  include_tasks: overcloud_nodes.yml
   delegate_to: "{{ groups['undercloud'] | first }}"
 
 - name: Add hosts to host list
   add_host:
-      name: "{{ item.name }}"
-      groups: "{{ ( item.name in groups.all ) | ternary(omit,
-          ['overcloud_nodes', 'openstack_nodes', item.name.split('-')[0]] | join(',')
-         ) }}"
-      ansible_ssh_user: "{{ overcloud_user }}"
-      ansible_ssh_pass: ""
-      ansible_ssh_host: "{{ item.accessIPv4 }}"
-      ansible_ssh_private_key_file: "{{ overcloud_private_key }}"
+    name: "{{ item.name }}"
+    groups: "{{ ( item.name in groups.all ) | ternary(omit,
+        ['overcloud_nodes', 'openstack_nodes', item.name.split('-')[0]] | join(',')
+       ) }}"
+    ansible_ssh_user: "{{ overcloud_user }}"
+    ansible_ssh_pass: ""
+    ansible_ssh_host: "{{ item.accessIPv4 }}"
+    ansible_ssh_private_key_file: "{{ overcloud_private_key }}"
   with_items: "{{ openstack_servers }}"
 
 - name: Enable SSH forwarding using Undercloud node for baremetal Overcloud nodes

--- a/tasks/undercloud_pass.yml
+++ b/tasks/undercloud_pass.yml
@@ -20,7 +20,7 @@
     undercloud_private_key_file: "{{ tripleo_undercloud_key }}"
   add_host:
     name: "{{ host }}"
-    groups: "undercloud,tester"
+    groups: "{{ undercloud_groups }}"
     ansible_ssh_host: "{{ host }}"
     ansible_ssh_user: "{{ user | default('stack') }}"
     ansible_ssh_private_key_file: "{{ undercloud_private_key_file }}"


### PR DESCRIPTION
- Undercloud could be used for various tasks like tester or something else.
  The tasks could use inventory groups.
  Change hardcoded definition of the undercloud groups to the variable.

  Currently, required by the infrared which looks for the 'shade' group
  within the inventory.

- Replace deprecated include with dynamic include - include_tasks.